### PR TITLE
Remove Local Cache initialization in fire-flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.1] - 2021-02-25
+
+### Fixed
+* Remove initial return as it causing the listener received the response twice. Let user handle feature flag initial value initialization
+
 ## [1.1.0] - 2020-12-02
 
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ fire_flag
 
 MIT License
 
-Copyright (c) [2020] [Evermos]
+Copyright (c) [2021] [Evermos]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add Fire Flag to your pubspec.yaml file:
 
 ```yaml
 dependencies:
-  fire_flag: ^1.1.0
+  fire_flag: ^1.1.1
 ```
 
 ## Usage

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.1.1"
   firebase_core:
     dependency: transitive
     description:

--- a/lib/src/fire_flag.dart
+++ b/lib/src/fire_flag.dart
@@ -47,10 +47,7 @@ class FireFlag {
   Stream<Features> featureFlagSubscription() async* {
     _remoteConfig = await RemoteConfig.instance;
 
-    ///1. Get the feature flag from Firebase Remote Config's local cache.
-    yield _featureFlagFromLocalStoredFirebaseRemoteConfig();
-
-    ///2. Fetch latest feature flag data from Firebase Remote Config and apply
+    ///Fetch latest feature flag data from Firebase Remote Config and apply
     ///them.
     yield await _featureFlagFromFirebaseRemoteConfigServer();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: fire_flag
 description: App wide feature flag manager utilizing the power of Firebase Remote Config.
-version: 1.1.0
+version: 1.1.1
 authors: 
-  - Muhammad Yusuf <yusuf@evermos.com>
+  - Evermos Tech <tech@evermos.com>
 homepage: https://github.com/evermos/fire-flag
 
 environment:
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.0
+  pedantic: ^1.9.2


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

In fire flag, it proactively returns local cache/initial value of the features requested, this not necessary, as user could handle this differently such as initiate the value then wait for real value , or wait for the value, and set value to default if timeout


## Type of change

<!--Please delete options that are not relevant.-->

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.-->

- [x] How to test
Compare old and new implementation
   1. open example, lib folder, put breakpoint on retrieveFeatureFlag
   2. Observe that it not return the value twice




## Checklist:
<!--
Put an `x` in the boxes that apply.
Use `~~` around the checklist items that are not applicable to this PR.
Examples:
- [x] I've done this
- ~~[ ] I don't need this~~
-->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] New and existing unit tests pass locally with my changes~~
- ~~[ ] Any dependent changes have been merged and published in downstream modules~~
- [x] I have checked my code and corrected any misspellings


## Description

## How to test